### PR TITLE
Add AGENTS.md for Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,19 +12,21 @@ This is the **PhageAgent** AI-Driven Task Orchestration System — a monorepo wi
 | Frontend UI | React 18 / TypeScript / Vite / Ant Design | 3000 | `cd web-ui && npm run dev` |
 | A-mem (optional) | FastAPI + ChromaDB + sentence-transformers | 8001 | `bash scripts/start_amem.sh` |
 
-### Running the backend without conda
+### Starting services
 
-The `start_backend.sh` script tries `conda activate LLM`. In environments without conda, bypass it by setting:
-
-```bash
-export BACKEND_PYTHON_BIN=$(which python3)
-```
-
-Or run uvicorn directly:
+The `start_backend.sh` script tries `conda activate LLM`. In Cloud Agent environments without conda, run uvicorn directly:
 
 ```bash
+# Backend (from /workspace)
 python3 -m uvicorn app.main:app --host 0.0.0.0 --port 9000 --reload
+
+# Frontend (separate terminal)
+cd web-ui && npm run dev
 ```
+
+Verify health: `curl http://localhost:9000/health` should return `{"status":"healthy",...}`.
+
+The frontend at port 3000 proxies `/api` and `/ws` to the backend at port 9000 (configured in `web-ui/vite.config.ts`).
 
 ### LLM API keys
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Architecture overview
+
+This is the **PhageAgent** AI-Driven Task Orchestration System — a monorepo with:
+
+| Service | Tech | Port | Dev command |
+|---------|------|------|-------------|
+| Backend API | Python / FastAPI / Uvicorn | 9000 | `python3 -m uvicorn app.main:app --host 0.0.0.0 --port 9000 --reload` |
+| Frontend UI | React 18 / TypeScript / Vite / Ant Design | 3000 | `cd web-ui && npm run dev` |
+| A-mem (optional) | FastAPI + ChromaDB + sentence-transformers | 8001 | `bash scripts/start_amem.sh` |
+
+### Running the backend without conda
+
+The `start_backend.sh` script tries `conda activate LLM`. In environments without conda, bypass it by setting:
+
+```bash
+export BACKEND_PYTHON_BIN=$(which python3)
+```
+
+Or run uvicorn directly:
+
+```bash
+python3 -m uvicorn app.main:app --host 0.0.0.0 --port 9000 --reload
+```
+
+### LLM API keys
+
+The backend requires at least one LLM provider API key to handle chat requests. Default provider is `qwen` (env var `QWEN_API_KEY`). Without it, the backend starts and passes health checks, but chat requests return `RuntimeError: QWEN_API_KEY is not set`. Other providers: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `KIMI_API_KEY`, `XAI_API_KEY`.
+
+### Running tests
+
+- **Backend**: `python3 -m pytest -q app/tests/` (see `app/tests/README.md` for marker details)
+- **Frontend**: `cd web-ui && npx vitest run`
+- **Type-check**: `cd web-ui && npx tsc --noEmit`
+
+Note: The repo does not include an `.eslintrc` config file, so `npm run lint` will fail with "couldn't find a configuration file".
+
+### Known environment-specific test failures
+
+- `test_real_app_terminal_http_and_websocket_roundtrip` and `test_ssh_backend_connect_read_write_disconnect` may fail due to `os.fork()` deprecation warnings in multi-threaded contexts and missing SSH backends. These are not code bugs.
+
+### Database
+
+SQLite is used (auto-created at `data/databases/main/plan_registry.db`). No external database setup needed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific development instructions for the PhageAgent codebase.

### What's included

- Architecture overview (backend, frontend, optional A-mem service)
- Instructions for starting services without conda
- LLM API key requirements documentation
- Test commands and known environment-specific test failures
- Database (SQLite) notes

### Environment verification performed

| Check | Status |
|-------|--------|
| Backend health (`/health`) | ✅ Pass |
| Frontend dev server (port 3000) | ✅ Pass |
| Frontend-backend communication | ✅ Pass |
| Real LLM chat interaction (QWEN) | ✅ Pass — full response with tool calls |
| Backend tests (`pytest`) | ✅ 381/383 passed (2 env-specific failures) |
| Frontend tests (`vitest`) | ✅ 23/24 passed (1 pre-existing failure) |
| TypeScript type-check (`tsc --noEmit`) | ✅ Pass |

### Hello-world demo

Successfully sent "What bioinformatics tools can you help me run?" to the chat UI and received a comprehensive response listing 30+ bioinformatics tools organized by category, with the LLM even invoking the `bio_tools` tool function to fetch the complete list.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3df0f1c4-aa8c-4b45-9603-54c2cf299896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3df0f1c4-aa8c-4b45-9603-54c2cf299896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

